### PR TITLE
Remove CareerContainer from home page

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -4,7 +4,6 @@ import FooterContainer from '@/components/home/footer.container'
 import PortfolioContainer from '@/components/home/portfolio.container'
 import ServicesContainer from '@/components/home/services.container'
 import ShowcaseSection from '@/components/home/showcase.section'
-import CareerContainer from '@/components/home/career.container'
 import NavbarContainer from '@/components/shared/navbar.container'
 import StarryBackground from '@/components/shared/StarryLayout'
 import useLang from '@/hooks/useLang'
@@ -76,7 +75,6 @@ export default function Page({ params: { locale } }: Props) {
 
       <ServicesContainer />
       <FeedbacksContainer />
-      <CareerContainer />
       <PortfolioContainer />
       <ContactMeContainer />
       <FooterContainer />


### PR DESCRIPTION
## Summary
- stop importing CareerContainer in main page
- remove CareerContainer section from main page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_6888a228c5388324a88aa4cd4e241293